### PR TITLE
Update Selenium.pm

### DIFF
--- a/lib/WWW/Selenium.pm
+++ b/lib/WWW/Selenium.pm
@@ -522,21 +522,7 @@ sub get_string_array {
     my $result = $self->get_string(@_);
     my $token = "";
     my @tokens = ();
-    my @chars = split(//, $result);
-    for (my $i = 0; $i < @chars; $i++) {
-        my $char = $chars[$i];
-        if ($char eq '\\') {
-            $i++;
-            $char = $chars[$i];
-            $token .= $char;
-        } elsif ($char eq ',') {
-            push (@tokens, $token);
-            $token = "";
-        } else {
-            $token .= $char;
-        }
-    }
-    push (@tokens, $token);
+    @tokens = map {s/\\(.)/\1/g; $_} split /(?<!\\),/, $result;
     return @tokens;
 }
 


### PR DESCRIPTION
Fixed bug in get_string_array where instead of correctly returning an empty array when there are no results it returns an array containing a single empty string. The new code uses a negative lookbehind assertion to split on unescaped commas. It then uses a map to remove the escape characters from the list of strings.
