### PR TITLE
added get_css_count method

### DIFF
--- a/lib/WWW/Selenium.pm
+++ b/lib/WWW/Selenium.pm
@@ -2801,6 +2801,29 @@ sub get_xpath_count {
     return $self->get_number("getXpathCount", @_);
 }
 
+=item $sel-E<gt>get_css_count($css)
+
+Returns the number of nodes that match the specified selector, eg. "css=table" would give the number of tables.
+
+=over
+
+=item $css is the css selector to evaluate. do NOT wrap this expression in a 'count()' function; we will do that for you..
+
+=back
+
+=over
+
+=item Returns the number of nodes that match the specified css selector
+
+=back
+
+=cut
+
+sub get_css_count {
+    my $self = shift;
+    return $self->get_number("getCssCount", @_);
+}
+
 =item $sel-E<gt>assign_id($locator, $identifier)
 
 Temporarily sets the "id" attribute of the specified element, so you can locate it in the futureusing its ID rather than a slow/complicated XPath.  This ID will disappear once the page isreloaded.

--- a/t/selenium-core.t
+++ b/t/selenium-core.t
@@ -127,6 +127,7 @@ $sel->_method_exists("get_element_height");
 $sel->_method_exists("get_cursor_position");
 $sel->_method_exists("get_expression");
 $sel->_method_exists("get_xpath_count");
+$sel->_method_exists("get_css_count");
 $sel->_method_exists("assign_id");
 $sel->_method_exists("allow_native_xpath");
 $sel->_method_exists("ignore_attributes_without_value");

--- a/target/iedoc.xml
+++ b/target/iedoc.xml
@@ -1441,6 +1441,17 @@ the number of tables.</comment>
 
 </function>
 
+<function name="getCssCount">
+
+<return type="number">the number of nodes that match the specified css selector</return>
+
+<param name="css">the css selector to evaluate. do NOT wrap this expression in a 'count()' function; we will do that for you.</param>
+
+<comment>Returns the number of nodes that match the specified selector, eg. "css=table" would give
+the number of tables.</comment>
+
+</function>
+
 <function name="assignId">
 
 <param name="locator">an <a href="#locators">element locator</a> pointing to an element</param>


### PR DESCRIPTION
I just started to use the module but the test script generated by Perl formatter failed due to lack of get_css_count method.

I updated iedoc.xml to latest one from selenium-2.40.0. The difference between the two versions is only the get_css_count part.

I tried to use create_www_selenium.pl but the POD was not qualified (also checked git log comment says so),  so manually appended the method, a test and the POD.
